### PR TITLE
Dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,19 +45,19 @@ jobs:
       - run:
           name: Configure AWS Access Key ID
           command: |
-            aws configure set aws_access_key_id \
+            ~/.local/bin/aws configure set aws_access_key_id \
             $AWS_ACCESS_KEY_ID \
             --profile default
       - run:
           name: Configure AWS Secret Access Key
           command: |
-            aws configure set aws_secret_access_key \
+            ~/.local/bin/aws configure set aws_secret_access_key \
             $AWS_SECRET_ACCESS_KEY \
             --profile default
       - run:
           name: Configure AWS default region
           command: |
-            aws configure set region $AWS_REGION \
+            ~/.local/bin/aws configure set region $AWS_REGION \
             --profile default
       - run:
           name: Upload to s3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
     docker:
       - image: circleci/python:3.6.3
     environment:
-      S3_BUCKET_NAME: hot-summit-staging
+      S3_BUCKET_NAME: summit2020-staging.hotosm.org
     steps:
       - attach_workspace:
           at: ./

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site
 .sass-cache
 .jekyll-metadata
 .DS_Store
+Gemfile.lock

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -836,7 +836,7 @@ em {
     }
   }
   .news-preview-details {
-    // padding: 24px 0;
+    padding: 24px;
   }
   .news-preview-image {
     img {

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ title: Home
 
 
 <div class="container">
-  <div class="highlight-module secondary-highlight-module" >
+  <div class="highlight-module secondary-highlight-module" height: 1200px >
     <div class="highlight-details">
       <div class="highlight-info">
         <div class="highlight-hr"></div>
@@ -23,9 +23,9 @@ title: Home
         <p>While a virtual meeting has its potential benefits, at HOT we feel the Summit represents a unique opportunity to meet, share experiences, learn from each other, collaborate and energize our staff, community, volunteers, partners and sponsors from around the world. Therefore, we will reschedule our live event.</p>
         <p></br></p>
         <p>In the meantime, we are taking the following measures:</p>
-        * We will follow up for Community input and a new date and location shortly</br>  
-* Ticket sales for the HOT Summit are suspended until we have a new date/venue</br>   
-* Program submissions are temporarily suspended and we will get in touch with those who have already submitted.</p>
+        - We will follow up for Community input and a new date and location shortly</br>  
+- Ticket sales for the HOT Summit are suspended until we have a new date/venue</br>   
+- Program submissions are temporarily suspended and we will get in touch with those who have already submitted.</p>
   <p></br></p>
         <p>We are looking forward to sharing information about the new dates and location when the global health crisis stabilizes. If you have any questions, please contact us: summit@hototsm.org.</p>
       </div>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ title: Home
         <h3>Summit Update</h3>
         <p>Due to the COVID-19 outbreak, the HOT Summit 2020 live event originally due to take place on 1-2 July in Cape Town, South Africa will be postponed. Although we hope that things will be back to normal by July, no one knows when regular travel and large gatherings will resume.</p>
         <p></br></p>
-        <p>We are looking forward to sharing information about the new dates and location when the global health crisis stabilizes. If you have any questions, please contact us: [summit@hototsm.org](mailto:summit@hototsm.org).</p>
+        <p>We are looking forward to sharing information about the new dates and location when the global health crisis stabilizes. If you have any questions, please contact us: summit@hototsm.org.</p>
       </div>
     </div>
     <div class="highlight-image">

--- a/index.html
+++ b/index.html
@@ -22,10 +22,10 @@ title: Home
     <p></br></p>
         <p>While a virtual meeting has its potential benefits, at HOT we feel the Summit represents a unique opportunity to meet, share experiences, learn from each other, collaborate and energize our staff, community, volunteers, partners and sponsors from around the world. Therefore, we will reschedule our live event.</p>
         <p></br></p>
-        <p>In the meantime, we are taking the following measures:</p>
-        - We will follow up for Community input and a new date and location shortly</br>  
-- Ticket sales for the HOT Summit are suspended until we have a new date/venue</br>   
-- Program submissions are temporarily suspended and we will get in touch with those who have already submitted.</p>
+        <p>In the meantime, we are taking the following measures:</br> 
+We will follow up for Community input and a new date and location shortly</br>  
+Ticket sales for the HOT Summit are suspended until we have a new date/venue</br>   
+Program submissions are temporarily suspended and we will get in touch with those who have already submitted.</p>
   <p></br></p>
         <p>We are looking forward to sharing information about the new dates and location when the global health crisis stabilizes. If you have any questions, please contact us: summit@hototsm.org.</p>
       </div>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ title: Home
         <h3>Summit Update</h3>
         <p>Due to the COVID-19 outbreak, the HOT Summit 2020 live event originally due to take place on 1-2 July in Cape Town, South Africa will be postponed. Although we hope that things will be back to normal by July, no one knows when regular travel and large gatherings will resume.</p>
         <p></br></p>
-        <p>We are looking forward to sharing information about the new dates and location when the global health crisis stabilizes. If you have any questions, please contact us: summit@hototsm.org.</p>
+        <p>We are looking forward to sharing information about the new dates and location when the global health crisis stabilizes. If you have any questions, please contact us: summit@hotosm.org.</p>
       </div>
     </div>
     <div class="highlight-image">
@@ -28,16 +28,20 @@ title: Home
 </div>
 
 <div class="container">
-   <p>The HOT Summit was planned to coincide with the State of the Map live event, however, the SOTM organizers have decided to hold a virtual event on 3-5 July instead of a live event.</p>
-    <p></br></p>
-        <p>While a virtual meeting has its potential benefits, at HOT we feel the Summit represents a unique opportunity to meet, share experiences, learn from each other, collaborate and energize our staff, community, volunteers, partners and sponsors from around the world. Therefore, we will reschedule our live event.</p>
-        <p></br></p>
-        <p>In the meantime, we are taking the following measures:</br> 
-* We will follow up for Community input and a new date and location shortly.</br>  
-* Ticket sales for the HOT Summit are suspended until we have a new date/venue.</br>   
-* Program submissions are temporarily suspended and we will get in touch with those who have already submitted.</p>
-  <p></br></p>
-  <div class="hr-h"></div>
+  <div class="module">
+    <div class="module-details article">
+      <p>The HOT Summit was planned to coincide with the State of the Map live event, however, the SOTM organizers have decided to hold a virtual event on 3-5 July instead of a live event.</p>
+      <p>While a virtual meeting has its potential benefits, at HOT we feel the Summit represents a unique opportunity to meet, share experiences, learn from each other, collaborate and energize our staff, community, volunteers, partners and sponsors from around the world. Therefore, we will reschedule our live event.</p>
+      <p>In the meantime, we are taking the following measures:</br> 
+        <ul>
+        <li>We will follow up for Community input and a new date and location shortly.</li>
+        <li>Ticket sales for the HOT Summit are suspended until we have a new date/venue.</li> 
+        <li>Program submissions are temporarily suspended and we will get in touch with those who have already submitted.</li>
+      </ul>
+      </p>
+      <p></br></p>
+    </div>
+  </div>
 </div>
 
 <div class="container">

--- a/index.html
+++ b/index.html
@@ -15,16 +15,15 @@ title: Home
     <div class="highlight-details">
       <div class="highlight-info">
         <div class="highlight-hr"></div>
-        <h3>Join us in Cape Town!</h3>
-        <p>The HOT Summit 2020 is coming to Cape Town, South Africa on July 1 - 2, 2020!</p>
-        <p><br/></p>
-        <p>Join the HOT community as we come together and showcase projects, share ideas, and celebrate 10 years of Humanitarian Mapping</p>
-        <p><br/></p>
-        <p><a href="/call-for-proposals">Call for proposals</a> and <a href="https://www.eventbrite.com/e/hot-summit-2020-cape-town-south-africa-tickets-98550604511">Early Registration</a> now open!</p>
-        <p><br/></p>
-      </div>
-      <div class="highlight-options">
-          <a href="https://www.eventbrite.com/e/hot-summit-2020-cape-town-south-africa-tickets-98550604511" class="btn btn-primary btn-lg btn-chevron">Early Bird Registration</a>
+        <h3>Summit Update</h3>
+        <p>Due to the COVID-19 outbreak, the HOT Summit 2020 live event originally due to take place on 1-2 July in Cape Town, South Africa will be postponed. Although we hope that things will be back to normal by July, no one knows when regular travel and large gatherings will resume.</p>
+        <p>The HOT Summit was planned to coincide with the State of the Map live event, however, the SOTM organizers have decided to hold a virtual event on 3-5 July instead of a live event.</p>
+        <p>While a virtual meeting has its potential benefits, at HOT we feel the Summit represents a unique opportunity to meet, share experiences, learn from each other, collaborate and energize our staff, community, volunteers, partners and sponsors from around the world. Therefore, we will reschedule our live event.</p>
+        <p>In the meantime, we are taking the following measures:</p>
+        * We will follow up for Community input and a new date and location shortly</br>  
+* Ticket sales for the HOT Summit are suspended until we have a new date/venue</br>   
+* Program submissions are temporarily suspended and we will get in touch with those who have already submitted.</p>
+        <p>We are looking forward to sharing information about the new dates and location when the global health crisis stabilizes. If you have any questions, please contact us: summit@hototsm.org.</p>
       </div>
     </div>
     <div class="highlight-image">

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ title: Home
         <h3>Summit Update</h3>
         <p>Due to the COVID-19 outbreak, the HOT Summit 2020 live event originally due to take place on 1-2 July in Cape Town, South Africa will be postponed. Although we hope that things will be back to normal by July, no one knows when regular travel and large gatherings will resume.</p>
         <p></br></p>
-        <p>We are looking forward to sharing information about the new dates and location when the global health crisis stabilizes. If you have any questions, please contact us: summit@hototsm.org.</p>
+        <p>We are looking forward to sharing information about the new dates and location when the global health crisis stabilizes. If you have any questions, please contact us: [summit@hototsm.org](mailto:summit@hototsm.org).</p>
       </div>
     </div>
     <div class="highlight-image">

--- a/index.html
+++ b/index.html
@@ -17,12 +17,16 @@ title: Home
         <div class="highlight-hr"></div>
         <h3>Summit Update</h3>
         <p>Due to the COVID-19 outbreak, the HOT Summit 2020 live event originally due to take place on 1-2 July in Cape Town, South Africa will be postponed. Although we hope that things will be back to normal by July, no one knows when regular travel and large gatherings will resume.</p>
+        <p></p>
         <p>The HOT Summit was planned to coincide with the State of the Map live event, however, the SOTM organizers have decided to hold a virtual event on 3-5 July instead of a live event.</p>
+    <p></p>
         <p>While a virtual meeting has its potential benefits, at HOT we feel the Summit represents a unique opportunity to meet, share experiences, learn from each other, collaborate and energize our staff, community, volunteers, partners and sponsors from around the world. Therefore, we will reschedule our live event.</p>
+        <p></p>
         <p>In the meantime, we are taking the following measures:</p>
         * We will follow up for Community input and a new date and location shortly</br>  
 * Ticket sales for the HOT Summit are suspended until we have a new date/venue</br>   
 * Program submissions are temporarily suspended and we will get in touch with those who have already submitted.</p>
+  <p></p>
         <p>We are looking forward to sharing information about the new dates and location when the global health crisis stabilizes. If you have any questions, please contact us: summit@hototsm.org.</p>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -18,15 +18,6 @@ title: Home
         <h3>Summit Update</h3>
         <p>Due to the COVID-19 outbreak, the HOT Summit 2020 live event originally due to take place on 1-2 July in Cape Town, South Africa will be postponed. Although we hope that things will be back to normal by July, no one knows when regular travel and large gatherings will resume.</p>
         <p></br></p>
-        <p>The HOT Summit was planned to coincide with the State of the Map live event, however, the SOTM organizers have decided to hold a virtual event on 3-5 July instead of a live event.</p>
-    <p></br></p>
-        <p>While a virtual meeting has its potential benefits, at HOT we feel the Summit represents a unique opportunity to meet, share experiences, learn from each other, collaborate and energize our staff, community, volunteers, partners and sponsors from around the world. Therefore, we will reschedule our live event.</p>
-        <p></br></p>
-        <p>In the meantime, we are taking the following measures:</br> 
-We will follow up for Community input and a new date and location shortly.</br>  
-Ticket sales for the HOT Summit are suspended until we have a new date/venue.</br>   
-Program submissions are temporarily suspended and we will get in touch with those who have already submitted.</p>
-  <p></br></p>
         <p>We are looking forward to sharing information about the new dates and location when the global health crisis stabilizes. If you have any questions, please contact us: summit@hototsm.org.</p>
       </div>
     </div>
@@ -37,6 +28,15 @@ Program submissions are temporarily suspended and we will get in touch with thos
 </div>
 
 <div class="container">
+   <p>The HOT Summit was planned to coincide with the State of the Map live event, however, the SOTM organizers have decided to hold a virtual event on 3-5 July instead of a live event.</p>
+    <p></br></p>
+        <p>While a virtual meeting has its potential benefits, at HOT we feel the Summit represents a unique opportunity to meet, share experiences, learn from each other, collaborate and energize our staff, community, volunteers, partners and sponsors from around the world. Therefore, we will reschedule our live event.</p>
+        <p></br></p>
+        <p>In the meantime, we are taking the following measures:</br> 
+* We will follow up for Community input and a new date and location shortly.</br>  
+* Ticket sales for the HOT Summit are suspended until we have a new date/venue.</br>   
+* Program submissions are temporarily suspended and we will get in touch with those who have already submitted.</p>
+  <p></br></p>
   <div class="hr-h"></div>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ title: Home
 
 
 <div class="container">
-  <div class="highlight-module secondary-highlight-module" height: 1200px >
+  <div class="highlight-module secondary-highlight-module">
     <div class="highlight-details">
       <div class="highlight-info">
         <div class="highlight-hr"></div>

--- a/index.html
+++ b/index.html
@@ -23,8 +23,8 @@ title: Home
         <p>While a virtual meeting has its potential benefits, at HOT we feel the Summit represents a unique opportunity to meet, share experiences, learn from each other, collaborate and energize our staff, community, volunteers, partners and sponsors from around the world. Therefore, we will reschedule our live event.</p>
         <p></br></p>
         <p>In the meantime, we are taking the following measures:</br> 
-We will follow up for Community input and a new date and location shortly</br>  
-Ticket sales for the HOT Summit are suspended until we have a new date/venue</br>   
+We will follow up for Community input and a new date and location shortly.</br>  
+Ticket sales for the HOT Summit are suspended until we have a new date/venue.</br>   
 Program submissions are temporarily suspended and we will get in touch with those who have already submitted.</p>
   <p></br></p>
         <p>We are looking forward to sharing information about the new dates and location when the global health crisis stabilizes. If you have any questions, please contact us: summit@hototsm.org.</p>

--- a/index.html
+++ b/index.html
@@ -17,16 +17,16 @@ title: Home
         <div class="highlight-hr"></div>
         <h3>Summit Update</h3>
         <p>Due to the COVID-19 outbreak, the HOT Summit 2020 live event originally due to take place on 1-2 July in Cape Town, South Africa will be postponed. Although we hope that things will be back to normal by July, no one knows when regular travel and large gatherings will resume.</p>
-        <p></p>
+        <p></br></p>
         <p>The HOT Summit was planned to coincide with the State of the Map live event, however, the SOTM organizers have decided to hold a virtual event on 3-5 July instead of a live event.</p>
-    <p></p>
+    <p></br></p>
         <p>While a virtual meeting has its potential benefits, at HOT we feel the Summit represents a unique opportunity to meet, share experiences, learn from each other, collaborate and energize our staff, community, volunteers, partners and sponsors from around the world. Therefore, we will reschedule our live event.</p>
-        <p></p>
+        <p></br></p>
         <p>In the meantime, we are taking the following measures:</p>
         * We will follow up for Community input and a new date and location shortly</br>  
 * Ticket sales for the HOT Summit are suspended until we have a new date/venue</br>   
 * Program submissions are temporarily suspended and we will get in touch with those who have already submitted.</p>
-  <p></p>
+  <p></br></p>
         <p>We are looking forward to sharing information about the new dates and location when the global health crisis stabilizes. If you have any questions, please contact us: summit@hototsm.org.</p>
       </div>
     </div>


### PR DESCRIPTION
Resubmitting. First time, the box on the main page that held the text wasn't expanding to accommodate the additional text. I worked around this by only putting the first paragraph with the announcement itself and the last paragraph with HOTOSM contact info into the box, and the three explanatory paragraphs below the box.